### PR TITLE
options.snapAmount : always snaps to a multiple of this number in pixels

### DIFF
--- a/grid_and_snap_while_scrolling_example.html
+++ b/grid_and_snap_while_scrolling_example.html
@@ -99,6 +99,7 @@
           scrollInertia:0,
           mouseWheelPixels:19,
           snapAmount:19,
+          snapOffset: 1,
           scrollButtons:{
             enable:true,
             scrollType:"pixels",

--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -35,6 +35,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/.
 				autoDraggerLength:true, /*auto-adjust scrollbar dragger length: boolean*/
 				autoHideScrollbar:false, /*auto-hide scrollbar when idle*/
 				snapAmount:null, /* optional element always snaps to a multiple of this number in pixels */
+				snapOffset:0, /* when snapping, snap with this number in pixels as an offset */
 				scrollButtons:{ /*scroll buttons*/
 					enable:false, /*scroll buttons support: boolean*/
 					scrollType:"continuous", /*scroll buttons scrolling type: "continuous", "pixels"*/
@@ -126,6 +127,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/.
 					"autoDraggerLength":options.autoDraggerLength,
 					"autoHideScrollbar":options.autoHideScrollbar,
 					"snapAmount":options.snapAmount,
+					"snapOffset":options.snapOffset,
 					"scrollButtons_enable":options.scrollButtons.enable,
 					"scrollButtons_scrollType":options.scrollButtons.scrollType,
 					"scrollButtons_scrollSpeed":options.scrollButtons.scrollSpeed,
@@ -678,7 +680,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/.
 						}else{scrollTo=-scrollTo;}
 						var snapAmount = $this.data("snapAmount");
 						if (snapAmount) {
-							scrollTo = Math.round(scrollTo / snapAmount) * snapAmount;
+							scrollTo = Math.round(scrollTo / snapAmount) * snapAmount - $this.data("snapOffset");
 						}
 						/*scrolling animation*/
 						functions.mTweenAxis.call(this,mCSB_dragger[0],"left",Math.round(draggerScrollTo),draggerSpeed,options.scrollEasing);
@@ -717,7 +719,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/.
 						}else{scrollTo=-scrollTo;}
 						var snapAmount = $this.data("snapAmount");
 						if (snapAmount) {
-							scrollTo = Math.round(scrollTo / snapAmount) * snapAmount;
+							scrollTo = Math.round(scrollTo / snapAmount) * snapAmount - $this.data("snapOffset");
 						}
 						/*scrolling animation*/
 						functions.mTweenAxis.call(this,mCSB_dragger[0],"top",Math.round(draggerScrollTo),draggerSpeed,options.scrollEasing);


### PR DESCRIPTION
This patch allows to set an option `snapAmount`. When set the content will always snap to a  multiple of that number in pixels.

See the demo in `grid_and_snap_while_scrolling_example.html`

Why?

If you look at the demo `scroll_buttons_and_snap_scrolling_examples.html` then it snaps when you use the buttons. However, when you scroll it ends up in a position that is not snapped.

If you have a grid and you scroll then the grid normally scrolls too. You easily end up in a situation where the top of the grid shows only a part of a row. The major downside of the grid lines scrolling is that it's also very uneasy on the eyes with all the lines moving.

With this `snapAmount` option you can scroll a grid while the grid seems to stay in place. Only the content within the grid seems to move. This makes it easy on the eyes. In addition no row is every shown partly. So the grid stays clean.

As far as I know this is the only javascript scrollbar component that can handle this.

The inspiration for this is taken from the way Google Drive's Spreadsheet scrolls cells within a grid.
