### PR TITLE
Change max-height function to take into consideration any padding applied to the DIV container

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -174,8 +174,12 @@ along with this program.  If not, see http://www.gnu.org/licenses/lgpl.html.
 							percentage=maxHeight,
 							maxHeight=$this.parent().height()*percentage/100;
 						}
+						var paddingTop = parseInt($this.css("padding-top"));
+						var paddingBottom = parseInt($this.css("padding-bottom"));
+						var paddingY = paddingTop + paddingBottom;
+
 						$this.css("overflow","hidden");
-						mCustomScrollBox.css("max-height",maxHeight);
+						mCustomScrollBox.css("max-height",maxHeight - paddingY);
 					}
 				}
 				$this.mCustomScrollbar("update");


### PR DESCRIPTION
Scrollbar is not rendered correctly when padding is present on the container DIV element and using only the max-height property. Added code to calculate the scrollbar height taking into consideration any applied padding.
