### PR TITLE
Check if the scrollbar is ready to use mousewheel events

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1250,40 +1250,43 @@ and dependencies (minified).
 			via mouse-wheel plugin (https://github.com/brandonaaron/jquery-mousewheel)
 			*/
 			_mousewheel:function(){
-				var $this=$(this),d=$this.data(pluginPfx),o=d.opt,
-					namespace=pluginPfx+"_"+d.idx,
-					mCustomScrollBox=$("#mCSB_"+d.idx),
-					mCSB_dragger=[$("#mCSB_"+d.idx+"_dragger_vertical"),$("#mCSB_"+d.idx+"_dragger_horizontal")];
-				mCustomScrollBox.bind("mousewheel."+namespace,function(e,delta){
-					functions._stop($this);
-					if(functions._disableMousewheel($this,e.target)){return;} /* disables mouse-wheel when hovering specific elements */
-					var deltaFactor=o.mouseWheel.deltaFactor!=="auto" ? parseInt(o.mouseWheel.deltaFactor) : (oldIE && e.deltaFactor<100) ? 100 : e.deltaFactor<40 ? 40 : e.deltaFactor || 100;
-					if(o.axis==="x" || o.mouseWheel.axis==="x"){
-						var dir="x",
-							px=[Math.round(deltaFactor*d.scrollRatio.x),parseInt(o.mouseWheel.scrollAmount)],
-							amount=o.mouseWheel.scrollAmount!=="auto" ? px[1] : px[0]>=mCustomScrollBox.width() ? mCustomScrollBox.width()*0.9 : px[0],
-							contentPos=Math.abs($("#mCSB_"+d.idx+"_container")[0].offsetLeft),
-							draggerPos=mCSB_dragger[1][0].offsetLeft,
-							limit=mCSB_dragger[1].parent().width()-mCSB_dragger[1].width(),
-							dlt=e.deltaX || e.deltaY || delta;
-					}else{
-						var dir="y",
-							px=[Math.round(deltaFactor*d.scrollRatio.y),parseInt(o.mouseWheel.scrollAmount)],
-							amount=o.mouseWheel.scrollAmount!=="auto" ? px[1] : px[0]>=mCustomScrollBox.height() ? mCustomScrollBox.height()*0.9 : px[0],
-							contentPos=Math.abs($("#mCSB_"+d.idx+"_container")[0].offsetTop),
-							draggerPos=mCSB_dragger[0][0].offsetTop,
-							limit=mCSB_dragger[0].parent().height()-mCSB_dragger[0].height(),
-							dlt=e.deltaY || delta;
-					}
-					if((dir==="y" && !d.overflowed[0]) || (dir==="x" && !d.overflowed[1])){return;}
-					if(o.mouseWheel.invert){dlt=-dlt;}
-					if(o.mouseWheel.normalizeDelta){dlt=dlt<0 ? -1 : 1;}
-					if((dlt>0 && draggerPos!==0) || (dlt<0 && draggerPos!==limit) || o.mouseWheel.preventDefault){
-						e.stopImmediatePropagation();
-						e.preventDefault();
-					}
-					functions._scrollTo($this,(contentPos-(dlt*amount)).toString(),{dir:dir});
-				});
+				var $this=$(this),d=$this.data(pluginPfx);
+				if (d) {
+					var o=d.opt,
+						namespace=pluginPfx+"_"+d.idx,
+						mCustomScrollBox=$("#mCSB_"+d.idx),
+						mCSB_dragger=[$("#mCSB_"+d.idx+"_dragger_vertical"),$("#mCSB_"+d.idx+"_dragger_horizontal")];
+					mCustomScrollBox.bind("mousewheel."+namespace,function(e,delta){
+						functions._stop($this);
+						if(functions._disableMousewheel($this,e.target)){return;} /* disables mouse-wheel when hovering specific elements */
+						var deltaFactor=o.mouseWheel.deltaFactor!=="auto" ? parseInt(o.mouseWheel.deltaFactor) : (oldIE && e.deltaFactor<100) ? 100 : e.deltaFactor<40 ? 40 : e.deltaFactor || 100;
+						if(o.axis==="x" || o.mouseWheel.axis==="x"){
+							var dir="x",
+								px=[Math.round(deltaFactor*d.scrollRatio.x),parseInt(o.mouseWheel.scrollAmount)],
+								amount=o.mouseWheel.scrollAmount!=="auto" ? px[1] : px[0]>=mCustomScrollBox.width() ? mCustomScrollBox.width()*0.9 : px[0],
+								contentPos=Math.abs($("#mCSB_"+d.idx+"_container")[0].offsetLeft),
+								draggerPos=mCSB_dragger[1][0].offsetLeft,
+								limit=mCSB_dragger[1].parent().width()-mCSB_dragger[1].width(),
+								dlt=e.deltaX || e.deltaY || delta;
+						}else{
+							var dir="y",
+								px=[Math.round(deltaFactor*d.scrollRatio.y),parseInt(o.mouseWheel.scrollAmount)],
+								amount=o.mouseWheel.scrollAmount!=="auto" ? px[1] : px[0]>=mCustomScrollBox.height() ? mCustomScrollBox.height()*0.9 : px[0],
+								contentPos=Math.abs($("#mCSB_"+d.idx+"_container")[0].offsetTop),
+								draggerPos=mCSB_dragger[0][0].offsetTop,
+								limit=mCSB_dragger[0].parent().height()-mCSB_dragger[0].height(),
+								dlt=e.deltaY || delta;
+						}
+						if((dir==="y" && !d.overflowed[0]) || (dir==="x" && !d.overflowed[1])){return;}
+						if(o.mouseWheel.invert){dlt=-dlt;}
+						if(o.mouseWheel.normalizeDelta){dlt=dlt<0 ? -1 : 1;}
+						if((dlt>0 && draggerPos!==0) || (dlt<0 && draggerPos!==limit) || o.mouseWheel.preventDefault){
+							e.stopImmediatePropagation();
+							e.preventDefault();
+						}
+						functions._scrollTo($this,(contentPos-(dlt*amount)).toString(),{dir:dir});
+					});
+				}
 			},
 			/* -------------------- */
 			


### PR DESCRIPTION
Sometimes the plugin throws this error :
"Uncaught TypeError: Cannot read property 'opt' of undefined"
Chrome 34 / Ubuntu 14.004

It could happen when we destroy the plugin before it is totally ready. It can be reproduce if you click repeatedly on "Destroy/Rebuild scrollbar" fastly on this page : http://manos.malihu.gr/repository/custom-scrollbar/demo/examples/disable_destroy_example.html 

or simplier here (look at the console errors) :

http://codepen.io/vtabary/pen/wiqAf

This is just a workaround, maybe there is a better way to do this.
