### PR TITLE
nwjs/Browserify Support

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -37,23 +37,26 @@ and dependencies (minified).
 */
 
 (function (factory) {
-  if(typeof module === "object" && typeof module.exports === "object") {
-    var $ = require("jquery");
-    require("jquery-mousewheel")($);
-    module.exports = factory($, window, document);
+  if(typeof module !== 'undefined' && module.exports) {
+    module.exports = factory;
   } else {
     factory(jQuery, window, document);
   }
-}(function($,window,document){
+}(function($){
 
 (function(init){
 	var _rjs=typeof define==="function" && define.amd, /* RequireJS */
+		_njs=typeof module !== 'undefined' && module.exports, /* NodeJS */
 		_dlp=("https:"==document.location.protocol) ? "https:" : "http:", /* location protocol */
 		_url="cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.12/jquery.mousewheel.min.js";
 	if(!_rjs){
-		/* load jquery-mousewheel plugin (via CDN) if it's not present or not loaded via RequireJS 
-		(works when mCustomScrollbar fn is called on window load) */
-		$.event.special.mousewheel || $("head").append(decodeURI("%3Cscript src="+_dlp+"//"+_url+"%3E%3C/script%3E"));
+		if (_njs) {
+			require("jquery-mousewheel")($);
+		} else {
+			/* load jquery-mousewheel plugin (via CDN) if it's not present or not loaded via RequireJS 
+			(works when mCustomScrollbar fn is called on window load) */
+			$.event.special.mousewheel || $("head").append(decodeURI("%3Cscript src="+_dlp+"//"+_url+"%3E%3C/script%3E"));
+		}
 	}
 	init();
 }(function(){

--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -36,7 +36,15 @@ the production-ready jquery.mCustomScrollbar.concat.min.js which contains the pl
 and dependencies (minified). 
 */
 
-;(function($,window,document){
+(function (factory) {
+  if(typeof module === "object" && typeof module.exports === "object") {
+    var $ = require("jquery");
+    require("jquery-mousewheel")($);
+    module.exports = factory($, window, document);
+  } else {
+    factory(jQuery, window, document);
+  }
+}(function($,window,document){
 
 (function(init){
 	var _rjs=typeof define==="function" && define.amd, /* RequireJS */
@@ -2279,4 +2287,4 @@ and dependencies (minified).
 	
 	});
 
-}))}(jQuery,window,document));
+}))}));

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "description": "Highly customizable custom scrollbar jQuery plugin, featuring vertical/horizontal scrollbars, scrolling momentum, mouse-wheel, keyboard and touch support user defined callbacks etc.",
   "license": "MIT",
   "homepage": "http://manos.malihu.gr/jquery-custom-content-scroller",
-  "main": [
-    "./jquery.mCustomScrollbar.js",
-    "./jquery.mCustomScrollbar.css",
-    "./mCSB_buttons.png"
-  ],
+  "main": "./jquery.mCustomScrollbar.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/malihu/malihu-custom-scrollbar-plugin.git"
@@ -31,7 +27,10 @@
   "jam": {
     "dependencies": {
       "jquery": ">=1.6",
-	  "jquery-mousewheel": ">=3.0.6"
+	    "jquery-mousewheel": ">=3.0.6"
     }
+  },
+  "dependencies": {
+    "jquery-mousewheel": ">=3.0.6"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,12 @@ npm: `npm install malihu-custom-scrollbar-plugin`
 
 `$(selector).mCustomScrollbar();` 
 
+###### Using with [Browserify](http://browserify.org/)
+
+    var $ = require('jquery');
+    require('malihu-custom-scrollbar-plugin')($);
+
+
 #### For more information 
 
 * [Plugin homepage and documentation](http://manos.malihu.gr/jquery-custom-content-scroller) 


### PR DESCRIPTION
I'm using this plugin in my app built with [nw.js](https://github.com/nwjs/nw.js/) [which allows for non-browser execution, like Browserify], this PR allows for nwjs/Browserify [closing #234] support by including the plugin via `require('malihu-custom-scrollbar-plugin');` instead of having to include the js script directly.

A detailed writeup on converting jQuery plugins to work with commonJS/Browserify can be found in this npm blog post: [Making your jQuery plugin work better with npm tools](http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm)

Specifically I needed to:
Change `package.json`:
- main field needs to point to an individual file: the ` jquery.mCustomScrollbar.js` file in our case.
- added `jquery-mousewheel` as a dependency so it doesn't have to be required externally.

Change `jquery.mCustomScrollbar.js`:
- check if this is a node environment and:
    - set.module.exports to export the plugin factory so it can be called/required externally.
    - allow the jQuery variable to be passed in, so we can reuse it instead of requiring our own.
    - require jquery-mousewheel using the passed in jQuery.


I also added a few lines to the Readme to clarify how to use it with Browserify.
