### PR TITLE
Propagate mousewheel event if ctrl key is pressed.

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1445,6 +1445,7 @@ and dependencies (minified).
 				_onMousewheel(e,delta);
 			});
 			function _onMousewheel(e,delta){
+				if (e.ctrlKey) return;
 				_stop($this);
 				if(_disableMousewheel($this,e.target)){return;} /* disables mouse-wheel when hovering specific elements */
 				var deltaFactor=o.mouseWheel.deltaFactor!=="auto" ? parseInt(o.mouseWheel.deltaFactor) : (oldIE && e.deltaFactor<100) ? 100 : e.deltaFactor || 100;


### PR DESCRIPTION
Typical browser behaviour allow us to zoom the page in/out by mouse wheel with control key pressed. It would be better if this behaviour still the same (Issue #319).

My change have been made and tested with Windows PC in Chrome and IE. I thought about Macs and I tried to test it on OS X Yosemite but it has no zoom feature by mousewheel at all. I googled how it can be enabled and found the following topic http://forums.macrumors.com/threads/zoom-with-control-mouse-wheel.1411306/ But after enabling "Use scroll gesture with..." nothing has changed and I decided to leave it as it is. By the way, jQuery.mousewheel event has no property commandKey and it should be determined by keyCode :)
