### PR TITLE
Add disableTouch advanced callback

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -309,6 +309,12 @@ and dependencies (minified).
 					releaseDraggableSelectors	null
 				*/
 				/*
+				callback used to disable touch event (parameters will be event and coordinates)
+					option						default
+					-------------------------------------
+					disableTouch				null
+				*/
+				/*
 				auto-update timeout 
 				values: integer (milliseconds)
 				*/
@@ -1291,8 +1297,11 @@ and dependencies (minified).
 					});
 				});
 			}
+			function isTouchDisabled(e) {
+				return o.advanced.disableTouch ? o.advanced.disableTouch(e, _coordinates(e)) : false;
+			}
 			function _onTouchstart(e){
-				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2]){touchable=0; return;}
+				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2] || isTouchDisabled(e)){touchable=0; return;}
 				touchable=1; touchDrag=0; docDrag=0; draggable=1;
 				$this.removeClass("mCS_touch_action");
 				var offset=mCSB_container.offset();
@@ -1301,7 +1310,7 @@ and dependencies (minified).
 				touchIntent=[_coordinates(e)[0],_coordinates(e)[1]];
 			}
 			function _onTouchmove(e){
-				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2]){return;}
+				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2] || isTouchDisabled(e)){return;}
 				if(!o.documentTouchScroll){e.preventDefault();} 
 				e.stopImmediatePropagation();
 				if(docDrag && !touchDrag){return;}
@@ -1335,7 +1344,7 @@ and dependencies (minified).
 				}
 			}
 			function _onTouchstart2(e){
-				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2]){touchable=0; return;}
+				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2] || isTouchDisabled(e)){touchable=0; return;}
 				touchable=1;
 				e.stopImmediatePropagation();
 				_stop($this);
@@ -1346,7 +1355,7 @@ and dependencies (minified).
 				touchMoveY=[]; touchMoveX=[];
 			}
 			function _onTouchend(e){
-				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2]){return;}
+				if(!_pointerTouch(e) || touchActive || _coordinates(e)[2] || isTouchDisabled(e)){return;}
 				draggable=0;
 				e.stopImmediatePropagation();
 				touchDrag=0; docDrag=0;


### PR DESCRIPTION
Add an advanced callback to let the developper disable touch event when some condtions applied.

In my case, I had a swipeleft/swiperight inside a scrolled content.
It was not working properly because the events was stopped.

Using jQuery mobile, I implemented it this way:

```
var touchStartAmplifier = false,
	touchAmplifierStoped = false;

$elm.mCustomScrollbar({
	/* ... */
	advanced: {
		disableTouch: function(e, coords) {
			if (e.type == 'touchstart') {
				if ($(e.target).closest('#SWIPE-CONTAINER').length > 0) {
					touchStartAmplifier = coords;
				} else {
					touchStartAmplifier = false;
				}
			} else if (e.type == 'touchmove' && touchStartAmplifier) {
				// already stoped
				if (touchAmplifierStoped)
					return true;
				
				var diffX = Math.abs(touchStartAmplifier[1] - coords[1]),
					diffY = Math.abs(touchStartAmplifier[0] - coords[0]);
				
				// Not enough drag yet to decide, stop it
				if (diffX < $.event.special.swipe.horizontalDistanceThreshold && diffY < $.event.special.swipe.verticalDistanceThreshold) {
					return true;
				}
				
				if (diffX > diffY) {
					touchAmplifierStoped = true;
					return true;
				} else {
					touchStartAmplifier = false;
				}
					
			} else if (e.type == 'touchend' && touchStartAmplifier) {
				touchStartAmplifier = false;
				if (touchAmplifierStoped) {
					touchAmplifierStoped = false;
					return true;
				}
			}
		}
	}
});
```

With this, touch work as before on every other elements.
When touch start on '#SWIPE-CONTAINER, it will wait until it can decide wether it's an horizontal or vertical gesture.
If horizontal, all other gestures will be stopped.
If vertical, all other gestures will pass through.

The result is only a small gap when the gesture has to pass through, which is acceptable in my case.

I tried to add the doc too, but I'm not sure if it will work correctly and fit your requirements.