### PR TITLE
Fixed on focus horizontal scroll position problem

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1623,7 +1623,7 @@ and dependencies (minified).
 						contentPos=[mCSB_container[0].offsetTop,mCSB_container[0].offsetLeft],
 						isVisible=[
 							(contentPos[0]+to[0]>=0 && contentPos[0]+to[0]<wrapper.height()-el.outerHeight(false)),
-							(contentPos[1]+to[1]>=0 && contentPos[0]+to[1]<wrapper.width()-el.outerWidth(false))
+							(contentPos[1]+to[1]>=0 && contentPos[1]+to[1]<wrapper.width()-el.outerWidth(false))
 						],
 						overwrite=(o.axis==="yx" && !isVisible[0] && !isVisible[1]) ? "none" : "all";
 					if(o.axis!=="x" && !isVisible[0]){

--- a/js/uncompressed/jquery.mCustomScrollbar.js
+++ b/js/uncompressed/jquery.mCustomScrollbar.js
@@ -1623,7 +1623,7 @@ and dependencies (minified).
 						contentPos=[mCSB_container[0].offsetTop,mCSB_container[0].offsetLeft],
 						isVisible=[
 							(contentPos[0]+to[0]>=0 && contentPos[0]+to[0]<wrapper.height()-el.outerHeight(false)),
-							(contentPos[1]+to[1]>=0 && contentPos[0]+to[1]<wrapper.width()-el.outerWidth(false))
+							(contentPos[1]+to[1]>=0 && contentPos[1]+to[1]<wrapper.width()-el.outerWidth(false))
 						],
 						overwrite=(o.axis==="yx" && !isVisible[0] && !isVisible[1]) ? "none" : "all";
 					if(o.axis!=="x" && !isVisible[0]){


### PR DESCRIPTION
Hello,
In this example (before changes and in Windows IE or Chrome) if we move down vertical scrollbar we can show part of a button. If we put the focus on the button, the scrollbar is not moving to right.
http://jsfiddle.net/o47xxuob/2/
This is because the position is not calculating well.

After my change, the same sample runs well.
http://jsfiddle.net/o47xxuob/3/
