### PR TITLE
Add some support for infinite scroll

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -2141,7 +2141,7 @@ and dependencies (minified).
 				},onUpdate:function(){
 					if(options.callbacks && options.onUpdate){
 						/* callbacks: whileScrolling */
-						if(_cb("whileScrolling")){_mcs(); o.callbacks.whileScrolling.call(el[0]);}
+						if(_cb("whileScrolling")){_mcs(); o.callbacks.whileScrolling.apply(el[0],[{options:options,delta:contentPos-scrollTo[0]}]);}
 					}
 				},onComplete:function(){
 					if(options.callbacks && options.onComplete){

--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1471,6 +1471,7 @@ and dependencies (minified).
 				_onMousewheel(e,delta);
 			});
 			function _onMousewheel(e,delta){
+				$(e.target).closest('.mCustomScrollbar').trigger('mcswheel',delta);
 				_stop($this);
 				if(_disableMousewheel($this,e.target)){return;} /* disables mouse-wheel when hovering specific elements */
 				var deltaFactor=o.mouseWheel.deltaFactor!=="auto" ? parseInt(o.mouseWheel.deltaFactor) : (oldIE && e.deltaFactor<100) ? 100 : e.deltaFactor || 100,


### PR DESCRIPTION
Hi ! Thanks for the plugin !

When scroll pos is 0 or reached the limit, mousewheel event is not propagated and whilescrolling callback is not called.

One way or another I need to know the mousewheel delta in this case, to trigger content loading for infinite scroll (eg when I start by displaying some item range at the middle of the data set and I need to scroll up)

The first patch https://github.com/malihu/malihu-custom-scrollbar-plugin/pull/527/commits/c3ae49449d9602fc56db99012236ca6f84c38df8 trigger a mcswheel event in order to achieve this, but you may implement it the way you like.. or maybe there was already another way ?..

The second patch https://github.com/malihu/malihu-custom-scrollbar-plugin/pull/527/commits/8efb2a6651d731fef9fa4c12876d988f6b431f51  fix another issue where I had to compare the current scrollPos with the previous on in the whileScrolling callback to determine the direction, but it was rather a hack and the method was not error prone. Passing the delta to the whileScrolling callback is a much better way (the delta could be normalized if somebody cares)...   Being here, passing "options" in the same object costs nothing and may be useful for #521 or another issue.

Cheers !



