### PR TITLE
Fixed bug with percent width holder.

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1024,7 +1024,7 @@ and dependencies (minified).
 				h=mCSB_container[0].scrollHeight,w=mCSB_container[0].scrollWidth;
 			if(h>contentHeight){contentHeight=h;}
 			if(w>contentWidth){contentWidth=w;}
-			return [contentHeight>mCustomScrollBox.height(),contentWidth>mCustomScrollBox.width()];
+			return [contentHeight>Math.round(mCustomScrollBox.height()),contentWidth>Math.round(mCustomScrollBox.width())];
 		},
 		/* -------------------- */
 		

--- a/js/uncompressed/jquery.mCustomScrollbar.js
+++ b/js/uncompressed/jquery.mCustomScrollbar.js
@@ -1024,7 +1024,7 @@ and dependencies (minified).
 				h=mCSB_container[0].scrollHeight,w=mCSB_container[0].scrollWidth;
 			if(h>contentHeight){contentHeight=h;}
 			if(w>contentWidth){contentWidth=w;}
-			return [contentHeight>mCustomScrollBox.height(),contentWidth>mCustomScrollBox.width()];
+			return [contentHeight>Math.round(mCustomScrollBox.height()),contentWidth>Math.round(mCustomScrollBox.width())];
 		},
 		/* -------------------- */
 		


### PR DESCRIPTION
When holder width is set with a percent (like 55%), then the scrollbar don't hide if a content width is less than holder width.