### PR TITLE
fix: Horizontal scroll touchpad if axis:"yx"

### DIFF
--- a/jquery.mCustomScrollbar.js
+++ b/jquery.mCustomScrollbar.js
@@ -1475,6 +1475,14 @@ and dependencies (minified).
 				if(_disableMousewheel($this,e.target)){return;} /* disables mouse-wheel when hovering specific elements */
 				var deltaFactor=o.mouseWheel.deltaFactor!=="auto" ? parseInt(o.mouseWheel.deltaFactor) : (oldIE && e.deltaFactor<100) ? 100 : e.deltaFactor || 100,
 					dur=o.scrollInertia;
+				if(o.axis==="yx"){
+					if(e.deltaX !== 0){
+						o.mouseWheel.axis = "x";
+					}
+					else if(e.deltaY !== 0) {
+						o.mouseWheel.axis = "y";
+					}
+				}
 				if(o.axis==="x" || o.mouseWheel.axis==="x"){
 					var dir="x",
 						px=[Math.round(deltaFactor*d.scrollRatio.x),parseInt(o.mouseWheel.scrollAmount)],


### PR DESCRIPTION
Problem: If settings is "axis: yx", then on touchPad I can't scroll horizontally
Solution in my case: I added this code and horizontal scroll worked